### PR TITLE
Fix inverted #ifdef for hlint

### DIFF
--- a/src/Data/Distributive.hs
+++ b/src/Data/Distributive.hs
@@ -32,7 +32,7 @@ import Data.Functor.Reverse
 import Data.Proxy
 import Data.Tagged
 
-#ifndef HLINT
+#ifdef HLINT
 {-# ANN module "hlint: ignore Use section" #-}
 #endif
 


### PR DESCRIPTION
The annotation should be used when using hlint, not when not using it.
This fixes builds without GHCi with GHC builds predating the fix for
https://ghc.haskell.org/trac/ghc/ticket/4268.
