### PR TITLE
Add Distributive instances for generic representations

### DIFF
--- a/src/Data/Distributive/Generic.hs
+++ b/src/Data/Distributive/Generic.hs
@@ -18,6 +18,7 @@ module Data.Distributive.Generic
   ) where
 
 import GHC.Generics
+import Data.Distributive
 
 -- | 'distribute' derived from a 'Generic1' type
 --
@@ -60,3 +61,9 @@ instance GDistributive f => GDistributive (Rec1 f) where
 instance GDistributive f => GDistributive (M1 i c f) where
   gdistribute = M1 . gdistribute . fmap unM1
   {-# INLINE gdistribute #-}
+
+instance Distributive U1
+instance (Distributive a, Distributive b) => Distributive (a :*: b)
+instance Distributive Par1
+instance Distributive f => Distributive (Rec1 f)
+instance Distributive f => Distributive (M1 i c f)

--- a/src/Data/Distributive/Generic.hs
+++ b/src/Data/Distributive/Generic.hs
@@ -62,6 +62,34 @@ instance GDistributive f => GDistributive (M1 i c f) where
   gdistribute = M1 . gdistribute . fmap unM1
   {-# INLINE gdistribute #-}
 
+-- Functor instances for the Generic types have only been available since 7.9
+#if __GLASGOW_HASKELL__ < 709
+instance Functor U1 where
+  fmap _ _ = U1
+
+instance Functor Par1 where
+  fmap f (Par1 x) = Par1 (f x)
+
+instance Functor f => Functor (Rec1 f) where
+  fmap f (Rec1 x) = Rec1 (fmap f x)
+
+instance Functor (K1 i c) where
+  fmap _ (K1 x) = K1 x
+
+instance Functor f => Functor (M1 i c f) where
+  fmap f (M1 x) = M1 (fmap f x)
+
+instance (Functor f, Functor g) => Functor (f :+: g) where
+  fmap f (L1 x) = L1 (fmap f x)
+  fmap f (R1 x) = R1 (fmap f x)
+
+instance (Functor f, Functor g) => Functor (f :*: g) where
+  fmap f (a :*: b) = fmap f a :*: fmap f b
+
+instance (Functor f, Functor g) => Functor (f :.: g) where
+  fmap f (Comp1 x) = Comp1 (fmap (fmap f) x)
+#endif
+
 instance Distributive U1
 instance (Distributive a, Distributive b) => Distributive (a :*: b)
 instance Distributive Par1


### PR DESCRIPTION
Previously these were available as `GDistributive` instances but not `Distributive` due to the `Functor` constraint. While the needed `Functor` instances are [coming for 7.10](https://ghc.haskell.org/trac/ghc/ticket/9043), we include orphans here for backwards compatibility.