### PR TITLE
InstalledPackageId replaced by ComponentId

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -5,7 +5,7 @@ module Main (main) where
 
 import Data.List ( nub )
 import Data.Version ( showVersion )
-import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
+import Distribution.Package ( PackageName(PackageName), PackageId, ComponentId, packageVersion, packageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
 import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
@@ -42,7 +42,7 @@ generateBuildModule verbosity pkg lbi = do
     formatone p = case packageName p of
       PackageName n -> n ++ "-" ++ showVersion (packageVersion p)
 
-testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(InstalledPackageId, PackageId)]
+testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(ComponentId, PackageId)]
 testDeps xs ys = nub $ componentPackageDeps xs ++ componentPackageDeps ys
 
 \end{code}


### PR DESCRIPTION
Fails to install with the latest Cabal. See https://github.com/haskell/cabal/commit/b08315 .