### PR TITLE
fix Setup.lhs for newer cabal

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -5,7 +5,7 @@ module Main (main) where
 
 import Data.List ( nub )
 import Data.Version ( showVersion )
-import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
+import Distribution.Package ( PackageName(PackageName), PackageId, UnitId, packageVersion, packageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
 import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
@@ -42,7 +42,7 @@ generateBuildModule verbosity pkg lbi = do
     formatone p = case packageName p of
       PackageName n -> n ++ "-" ++ showVersion (packageVersion p)
 
-testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(InstalledPackageId, PackageId)]
+testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(UnitId, PackageId)]
 testDeps xs ys = nub $ componentPackageDeps xs ++ componentPackageDeps ys
 
 \end{code}


### PR DESCRIPTION
can't use `MIN_VERSION_Cabal` MIN_VERSION_Cabal is a macro from cabal_macros.h that is generated by Setup.lhs
break everything for everyone