### PR TITLE
Fixed the order of type arguments to correspond to Distributive methods

### DIFF
--- a/src/Data/Distributive.hs
+++ b/src/Data/Distributive.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Distributive

--- a/src/Data/Distributive.hs
+++ b/src/Data/Distributive.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Distributive
@@ -114,7 +115,7 @@ class Functor g => Distributive g where
 -- @
 -- 'cotraverse' f = 'fmap' f . 'distribute'
 -- @
-cotraverse :: (Functor f, Distributive g) => (f a -> b) -> f (g a) -> g b
+cotraverse :: (Distributive g, Functor f) => (f a -> b) -> f (g a) -> g b
 cotraverse f = fmap f . distribute
 
 -- | The dual of 'Data.Traversable.mapM'
@@ -122,7 +123,7 @@ cotraverse f = fmap f . distribute
 -- @
 -- 'comapM' f = 'fmap' f . 'distributeM'
 -- @
-comapM :: (Monad m, Distributive g) => (m a -> b) -> m (g a) -> g b
+comapM :: (Distributive g, Monad m) => (m a -> b) -> m (g a) -> g b
 comapM f = fmap f . distributeM
 
 instance Distributive Identity where


### PR DESCRIPTION
The parent type class is the first argument of methods, make `cotraverse` and `comapM` follow that example:

```haskell
distribute @(Backwards _) :: 
  (Distributive t, Functor f) => f (Backwards t a) -> Backwards t (f a)

cotraverse @(Backwards _) :: 
  (Distributive t, Functor f) => (f a -> b) -> f (Backwards t a) -> Backwards t b

comapM @(Backwards _) :: 
  (Distributive t, Monad m) => (m a -> b) -> m (Backwards t a) -> Backwards t b
```