### PR TITLE
Fix the GDistributive instances for Rec1 and (:.:)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+0.5.2
+-----
+* Fix bugs in the implementation of `genericDistribute` that cause it not to
+  work properly for datatypes with recursive types
+
 0.5.1
 -----
 * Add `Distributive` instances for datatypes from `Data.Semigroup` and `GHC.Generics`

--- a/distributive.cabal
+++ b/distributive.cabal
@@ -1,6 +1,6 @@
 name:          distributive
 category:      Data Structures
-version:       0.5.1
+version:       0.5.2
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE

--- a/src/Data/Distributive/Generic.hs
+++ b/src/Data/Distributive/Generic.hs
@@ -17,6 +17,7 @@ module Data.Distributive.Generic
   , genericDistribute
   ) where
 
+import Data.Distributive
 import GHC.Generics
 
 -- | 'distribute' derived from a 'Generic1' type
@@ -45,16 +46,16 @@ instance (GDistributive a, GDistributive b) => GDistributive (a :*: b) where
     sndP (_ :*: r) = r
   {-# INLINE gdistribute #-}
 
-instance (Functor a, GDistributive a, GDistributive b) => GDistributive (a :.: b) where
-  gdistribute = Comp1 . fmap gdistribute . gdistribute . fmap unComp1
+instance (Functor a, Distributive a, GDistributive b) => GDistributive (a :.: b) where
+  gdistribute = Comp1 . fmap gdistribute . distribute . fmap unComp1
   {-# INLINE gdistribute #-}
 
 instance GDistributive Par1 where
   gdistribute = Par1 . fmap unPar1
   {-# INLINE gdistribute #-}
 
-instance GDistributive f => GDistributive (Rec1 f) where
-  gdistribute = Rec1 . gdistribute . fmap unRec1
+instance Distributive f => GDistributive (Rec1 f) where
+  gdistribute = Rec1 . distribute . fmap unRec1
   {-# INLINE gdistribute #-}
 
 instance GDistributive f => GDistributive (M1 i c f) where


### PR DESCRIPTION
Currently, `genericDistributive` simply doesn't work at all for any datatype that uses `Rec1` or `(:.:)` in its generic representation type, since it incorrectly expects the underlying type to be an instance of `GDistributive`, not `Distributive`. As a result, you can't use `genericDistribute` to define an instance for a datatype like `data Stream a = a <: Stream a`. Luckily, it's an easy fix.