### PR TITLE
Add test suite for generics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ script:
      cabal)
        cabal configure --enable-tests -v2;
        cabal build;
-       cabal test;
+       cabal test --show-details=always;
        cabal bench || true;
        cabal sdist || true;
        SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz && (cd dist && cabal install --force-reinstalls "$SRC_TGZ");;

--- a/distributive.cabal
+++ b/distributive.cabal
@@ -82,3 +82,18 @@ test-suite doctests
     filepath  >= 1.2
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
+
+test-suite spec
+  type:           exitcode-stdio-1.0
+  hs-source-dirs: tests
+
+  build-depends:
+    base             >= 4    && < 5,
+    distributive,
+    generic-deriving >= 1.11 && < 2,
+    hspec            >= 2    && < 3
+
+  main-is: Spec.hs
+  other-modules: GenericsSpec
+
+  ghc-options: -Wall -threaded -rtsopts

--- a/tests/GenericsSpec.hs
+++ b/tests/GenericsSpec.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE DeriveGeneric #-}
+#endif
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  GenericSpec
+-- Copyright   :  (C) 2011-2016 Edward Kmett
+-- License     :  BSD-style (see the file LICENSE)
+--
+-- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+-- Stability   :  provisional
+--
+-- Tests for generically derived 'Distributive' instances.
+----------------------------------------------------------------------------
+module GenericsSpec (main, spec) where
+
+import Test.Hspec
+
+#if __GLASGOW_HASKELL__ >= 702
+import           Data.Distributive (Distributive(..))
+import           Data.Distributive.Generic (genericDistribute)
+
+# if __GLASGOW_HASKELL__ >= 706
+import           Generics.Deriving.Base hiding (Rep)
+# else
+import qualified Generics.Deriving.TH as Generics (deriveAll1)
+# endif
+#endif
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+#if __GLASGOW_HASKELL__ < 702
+spec = return ()
+#else
+spec = do
+  describe "Id" $
+    it "distribute idExample = idExample" $
+      distribute idExample `shouldBe` idExample
+  describe "Stream" $
+    it "runId (shead (stail (distribute streamExample))) = 1" $
+      runId (shead (stail (distribute streamExample))) `shouldBe` 1
+  describe "PolyRec" $
+    it "runId (plast (runId (pinit (distribute polyRecExample)))) = 1" $
+      runId (plast (runId (pinit (distribute polyRecExample)))) `shouldBe` 1
+
+newtype Id a = Id { runId :: a }
+  deriving (Eq, Functor, Show)
+instance Distributive Id where
+  distribute = genericDistribute
+
+idExample :: Id (Id Int)
+idExample = Id (Id 42)
+
+data Stream a = (:>) { shead :: a, stail :: Stream a }
+  deriving Functor
+instance Distributive Stream where
+  distribute = genericDistribute
+
+streamExample :: Id (Stream Int)
+streamExample = Id $ let s = 0 :> fmap (+1) s in s
+
+data PolyRec a = PolyRec { pinit :: Id (PolyRec a), plast :: a }
+  deriving Functor
+instance Distributive PolyRec where
+  distribute = genericDistribute
+
+polyRecExample :: Id (PolyRec Int)
+polyRecExample = Id $ let p = PolyRec (Id $ fmap (+1) p) 0 in p
+
+# if __GLASGOW_HASKELL__ >= 706
+deriving instance Generic1 Id
+deriving instance Generic1 Stream
+deriving instance Generic1 PolyRec
+# else
+$(Generics.deriveAll1 ''Id)
+$(Generics.deriveAll1 ''Stream)
+$(Generics.deriveAll1 ''PolyRec)
+# endif
+#endif

--- a/tests/GenericsSpec.hs
+++ b/tests/GenericsSpec.hs
@@ -25,7 +25,7 @@ import Test.Hspec
 
 #if __GLASGOW_HASKELL__ >= 702
 import           Data.Distributive (Distributive(..))
-import           Data.Distributive.Generic (genericDistribute)
+import           Data.Distributive.Generic (genericCollect, genericDistribute)
 
 # if __GLASGOW_HASKELL__ >= 706
 import           Generics.Deriving.Base hiding (Rep)
@@ -55,6 +55,7 @@ spec = do
 newtype Id a = Id { runId :: a }
   deriving (Eq, Functor, Show)
 instance Distributive Id where
+  collect    = genericCollect
   distribute = genericDistribute
 
 idExample :: Id (Id Int)
@@ -63,6 +64,7 @@ idExample = Id (Id 42)
 data Stream a = (:>) { shead :: a, stail :: Stream a }
   deriving Functor
 instance Distributive Stream where
+  collect    = genericCollect
   distribute = genericDistribute
 
 streamExample :: Id (Stream Int)
@@ -71,6 +73,7 @@ streamExample = Id $ let s = 0 :> fmap (+1) s in s
 data PolyRec a = PolyRec { pinit :: Id (PolyRec a), plast :: a }
   deriving Functor
 instance Distributive PolyRec where
+  collect    = genericCollect
   distribute = genericDistribute
 
 polyRecExample :: Id (PolyRec Int)

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
Add regression tests for `Data.Distributive.Generic` issues that were fixed in #22. In the same vein https://github.com/ekmett/adjunctions/pull/38.