### PR TITLE
Add missing dependencies in 'custom-setup' section

### DIFF
--- a/distributive.cabal
+++ b/distributive.cabal
@@ -28,6 +28,8 @@ source-repository head
 custom-setup
   setup-depends:
     base >= 4 && <5,
+    filepath,
+    directory,
     Cabal,
     cabal-doctest >= 1 && <1.1
 


### PR DESCRIPTION
This fixes builds with ghcjs.