### PR TITLE
Bump semigroups lower bound

### DIFF
--- a/distributive.cabal
+++ b/distributive.cabal
@@ -70,7 +70,7 @@ library
 
   if impl(ghc < 8.0)
     if flag(semigroups)
-      build-depends: semigroups >= 0.11 && < 1
+      build-depends: semigroups >= 0.13 && < 1
 
   if impl(ghc < 7.8)
     hs-source-dirs: src-compat


### PR DESCRIPTION
We need Functor Semi.Max etc, introduced in semigroups-0.13

---

I made revisions for affected versions: 0.5.1, 0.5.2 and 0.5.3