### PR TITLE
Bump base-orphans lower bound to >=0.5.2

### DIFF
--- a/distributive.cabal
+++ b/distributive.cabal
@@ -60,7 +60,7 @@ flag tagged
 library
   build-depends:
     base                >= 4   && < 5,
-    base-orphans        >= 0.5 && < 1,
+    base-orphans        >= 0.5.2 && < 1,
     transformers        >= 0.2 && < 0.6,
     transformers-compat >= 0.3 && < 1
 


### PR DESCRIPTION
We need `Functor` instances for `GHC.Generics` for their `Distributive`
instances. 

I made proper revisions for affected released versions:
- https://hackage.haskell.org/package/distributive-0.5.1/revisions/
- https://hackage.haskell.org/package/distributive-0.5.2/revisions/
- https://hackage.haskell.org/package/distributive-0.5.3/revisions/