### PR TITLE
Tidy up dependencies

### DIFF
--- a/distributive.cabal
+++ b/distributive.cabal
@@ -61,8 +61,10 @@ library
   build-depends:
     base                >= 4   && < 5,
     base-orphans        >= 0.5.2 && < 1,
-    transformers        >= 0.2 && < 0.6,
-    transformers-compat >= 0.3 && < 1
+    transformers        >= 0.2 && < 0.6
+
+  if !impl(ghc > 7.8)
+    build-depends: transformers-compat >= 0.3 && < 1
 
   hs-source-dirs:  src
   exposed-modules:


### PR DESCRIPTION
This removes a dependency on `transformers-compat` for new versions of GHC