### PR TITLE
Fix distributive check for transformers-compat

### DIFF
--- a/distributive.cabal
+++ b/distributive.cabal
@@ -63,7 +63,7 @@ library
     base-orphans        >= 0.5.2 && < 1,
     transformers        >= 0.2 && < 0.6
 
-  if !impl(ghc > 7.8)
+  if impl(ghc <= 7.8)
     build-depends: transformers-compat >= 0.3 && < 1
 
   hs-source-dirs:  src


### PR DESCRIPTION
This check didn't work when using ghcjs. The ghc version check will be false when using ghcjs, causing transformer-compat to be pulled in.