### PR TITLE
Require at least transformers-0.3

### DIFF
--- a/distributive.cabal
+++ b/distributive.cabal
@@ -65,10 +65,7 @@ library
   build-depends:
     base                >= 4   && < 5,
     base-orphans        >= 0.5.2 && < 1,
-    transformers        >= 0.2 && < 0.6
-
-  if !impl(ghc >= 7.8) && !impl(ghcjs)
-    build-depends: transformers-compat >= 0.3 && < 1
+    transformers        >= 0.3 && < 0.6
 
   hs-source-dirs:  src
   exposed-modules:


### PR DESCRIPTION
This allows to drop transformers-compat dependency,
and also fixes build on GHC-7.8.4, which allowed
picking transformers-0.2,
and thus making `Data.Distributive` module
fail to compile.

Note: transformers-0.3 is the oldest release any GHC ships,
so this change doens't affect `installed` constrained
builds.

Affected versions: 0.6 0.6.1 0.6.2
Corresponding revision made on Hackage.