### PR TITLE
Add safe-haskell-flags

### DIFF
--- a/distributive.cabal
+++ b/distributive.cabal
@@ -87,6 +87,12 @@ library
     other-modules: Data.Coerce
 
   ghc-options: -Wall
+
+  if impl(ghc >= 9.0)
+    -- these flags may abort compilation with GHC-8.10
+    -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3295
+    ghc-options: -Winferred-safe-imports -Wmissing-safe-haskell-mode
+
   default-language: Haskell2010
 
 -- Verify the results of the examples


### PR DESCRIPTION
For distributive they are not really doing anything,
as all (both) modules are `Trustworthy` due imports of unsafe modules
(in particular `Data.Coerce` which is explicitly `Unsafe`).

Yet, I think it's good to have these flags enabled
for uniformity.

EDIT: for that reason we don't need to e.g. bump `tagged` lower bound here.