### PR TITLE
Make it compile with MicroHs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+dist-mcabal

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 dist
-dist-newstyle
+dist-*
 docs
 wiki
 TAGS
@@ -30,4 +30,3 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
-dist-mcabal

--- a/src/Data/Distributive/Generic.hs
+++ b/src/Data/Distributive/Generic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -15,14 +16,17 @@
 ----------------------------------------------------------------------------
 module Data.Distributive.Generic
   ( GDistributive(..)
+#ifdef __GLASGOW_HASKELL__
   , genericCollect
   , genericDistribute
+#endif
   ) where
 
 import Data.Distributive
 import GHC.Generics
 import Data.Coerce
 
+#ifdef __GLASGOW_HASKELL__
 -- | 'collect' derived from a 'Generic1' type
 --
 -- This can be used to easily produce a 'Distributive' instance for a
@@ -39,6 +43,7 @@ genericCollect f = to1 . gcollect (from1 . f)
 -- It's often more efficient to use 'genericCollect' instead.
 genericDistribute  :: (Functor f, Generic1 g, GDistributive (Rep1 g)) => f (g a) -> g (f a)
 genericDistribute = to1 . gdistribute . fmap from1
+#endif
 
 
 -- Can't distribute over,

--- a/src/Data/Distributive/Generic.hs
+++ b/src/Data/Distributive/Generic.hs
@@ -26,6 +26,7 @@ import Data.Distributive
 import GHC.Generics
 import Data.Coerce
 
+-- This part is GHC only, since MicroHs doesn't support type families (Rep1) yet.
 #ifdef __GLASGOW_HASKELL__
 -- | 'collect' derived from a 'Generic1' type
 --


### PR DESCRIPTION
MicroHs unfortunately doesn't support type families yet. Should I add a CI job to compile with MicroHs? It could either always use the latest MicroHs commit (this might occasionally break) or a fixed commit (this might get outdated).